### PR TITLE
completed sql-delete

### DIFF
--- a/sql-delete/.npmrc
+++ b/sql-delete/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/sql-delete/bizarre.sql
+++ b/sql-delete/bizarre.sql
@@ -1,0 +1,3 @@
+delete from "cities"
+where "name" = 'Pyongyang'
+returning *;

--- a/sql-delete/diplomat.sql
+++ b/sql-delete/diplomat.sql
@@ -1,0 +1,3 @@
+delete from "addresses"
+where "addressId" = 161
+returning *;

--- a/sql-delete/puritanical.sql
+++ b/sql-delete/puritanical.sql
@@ -1,0 +1,3 @@
+delete from "films"
+where "rating" != 'G'
+returning *;

--- a/sql-delete/sanction.sql
+++ b/sql-delete/sanction.sql
@@ -1,0 +1,3 @@
+delete from "countries"
+where "countryId" = 70
+returning *;


### PR DESCRIPTION
I realized I didn't get anything returned on terminal when I ran psql -d pagila -f command for diplomat.sql because I already ran the query from pgweb :( I did confirm the address was deleted from the database. Please let me know if I need to adjust anything.

![1](https://user-images.githubusercontent.com/63431636/137046951-5cdeba25-807c-4b35-9cc0-439155ae625c.JPG)

